### PR TITLE
Remove isNaN() check when checking if array isArrayOfNumbers()

### DIFF
--- a/src/Measures.ts
+++ b/src/Measures.ts
@@ -675,7 +675,7 @@ export class EnrichmentScore extends ASimilarityMeasure {
 
   isArrayOfNumbers(arr: any): arr is number[] {
     if (Array.isArray(arr)) {
-      return arr.every((item) => item === null || typeof item === 'number' || isNaN(item));
+      return arr.every((item) => item === null || typeof item === 'number');
     }
     return false;
   }


### PR DESCRIPTION
Closes Caleydo/tourdino#34


### Summary
The issue was that i was checking if an array is an array of numbers like below:

https://github.com/Caleydo/tourdino/blob/8a70ec83e29aa1e48dc5ae075ce62dd0b4673ad8/src/Measures.ts#L676-L681

Removing the `isNaN()` check brings the performance back to normal.

![result](https://user-images.githubusercontent.com/51322092/76083496-120cd300-5fae-11ea-93f1-ea65c53bcf45.gif)

