### PR TITLE
Use accessor as ID to identify scores

### DIFF
--- a/src/RankingAdapter.ts
+++ b/src/RankingAdapter.ts
@@ -1,10 +1,15 @@
 import {LocalDataProvider, IColumnDesc, ICategory, Column, Ranking, IDataRow} from 'lineupjs';
 import {IServerColumn} from 'tdp_core/src/rest';
 import {isProxyAccessor} from './util';
+import {IAccessorFunc} from 'tdp_core/src/lineup/internal/utils';
 
 
 export interface IAttributeCategory extends ICategory {
   attribute: IServerColumn;
+}
+
+export interface IAccessorColumn extends Column {
+  accessor: IAccessorFunc<any>;
 }
 
 export class RankingAdapter {
@@ -30,11 +35,12 @@ export class RankingAdapter {
     return this.provider;
   }
 
-
+  /**
+   * Identify scores through their accessor function.
+   */
   private getScoreColumns() {
-    return this.getDisplayedAttributes().filter((attr) => (attr.desc as any)._score);
+    return this.getDisplayedAttributes().filter((attr) => isProxyAccessor((<IAccessorColumn>attr).accessor));
   }
-
 
   private oldOrder: Array<number> = new Array();
   private oldSelection: Array<number> = new Array();


### PR DESCRIPTION
Closes Caleydo/tourdino#36


### Summary 

- Used **accessor** column property to identify scores. Thus the function  
`getScoreColumns()` returns all added scores instead of ignoring the ones without
the **_score** property.

### Result
   
![result](https://user-images.githubusercontent.com/51322092/76087009-957df280-5fb5-11ea-8656-2e7dc0f996e8.png)

