### PR TITLE
Further performace improvements

### DIFF
--- a/src/RankingAdapter.ts
+++ b/src/RankingAdapter.ts
@@ -94,7 +94,9 @@ export class RankingAdapter {
 
       const groups = this.getRanking().getGroups();
       const groupIndexArray = groups.map((g) => {
-        return g.order.map((order) => order);
+        const groupMap = new Map<number, number>();
+        g.order.forEach((order, i) => {groupMap.set(order, i);});
+        return groupMap;
       });
 
       this.oldSelection = this.getSelectionUnsorted();
@@ -106,7 +108,7 @@ export class RankingAdapter {
 
         // include wether the row is selected
         item[RankingAdapter.SELECTION_COLUMN_ID] = this.oldSelection.includes(i) ? 'Selected' : 'Unselected';
-        const groupIndex = groupIndexArray.findIndex((groupIndex) => groupIndex.includes(i));
+        const groupIndex = groupIndexArray.findIndex((map) => map.has(i));
         const groupName = groupIndex === -1 ? 'Unknown' : groups[groupIndex].name;
         item[RankingAdapter.GROUP_COLUMN_ID] = groupName; // index of group = category name, find index by looking up i. -1 if not found
         databaseData.push(item);


### PR DESCRIPTION
### Summary

Using `map.has()` instead of `array.includes()` has a substantial impact on performance.
Tested it with 20000 rows both in _chrome_ and _firefox_ and the times are as follows:

*  `array.includes()`:
![originalTime](https://user-images.githubusercontent.com/51322092/76196426-8469f700-61ea-11ea-9152-b531a34a730a.png)
 
* `map.has()`:
![newTime](https://user-images.githubusercontent.com/51322092/76196492-9a77b780-61ea-11ea-9ee4-9582ee372340.png)

We had this already  implemented in PR Caleydo/tourdino#18
but we removed it during the review process because we considered it was redundant.

To test it use the` console.time(ID)` and `console.timeEnd(ID)` functions both on the original branch and this one.