### PR TITLE
Add ES5 accessor string in `isProxyAccessor`

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@types/node": "^13.7.7"
   },
   "dependencies": {
-    "tdp_core": "github:datavisyn/tdp_core#thinkh/refactor-paneltab-extension-point",
+    "tdp_core": "github:datavisyn/tdp_core#ochampari/10_tourdino-lineup-panel-button",
     "@types/d3": "~3.5.36",
     "@types/jquery": "3.3.33",
     "@types/node": "^13.7.7",

--- a/src/RankingAdapter.ts
+++ b/src/RankingAdapter.ts
@@ -1,6 +1,6 @@
 import {LocalDataProvider, IColumnDesc, ICategory, Column, Ranking, IDataRow} from 'lineupjs';
 import {IServerColumn} from 'tdp_core/src/rest';
-import {isProxyAccessor} from './util';
+import {isScoreColumn} from './util';
 import {IAccessorFunc} from 'tdp_core/src/lineup/internal/utils';
 
 
@@ -36,10 +36,10 @@ export class RankingAdapter {
   }
 
   /**
-   * Identify scores through their accessor function.
+   * Identify scores through their `lazyLoaded` attribute.
    */
   private getScoreColumns() {
-    return this.getDisplayedAttributes().filter((attr) => isProxyAccessor((<IAccessorColumn>attr).accessor));
+    return this.getDisplayedAttributes().filter((attr) => isScoreColumn(attr.desc));
   }
 
   private oldOrder: Array<number> = new Array();
@@ -168,7 +168,7 @@ export class RankingAdapter {
    */
   public getItemRanks() {
     let i = 0;
-    return this.getItemOrder().map((id) => ({ _id: id, rank: i++ }));
+    return this.getItemOrder().map((id) => ({_id: id, rank: i++}));
   }
 
   public getRanking(): Ranking {
@@ -239,7 +239,7 @@ export class RankingAdapter {
     const ids = this.getDisplayedIds();
     const data = [];
 
-    if (desc.column && isProxyAccessor(accessor)) {
+    if (desc.column && isScoreColumn(desc)) {
       for (const id of ids) {
         const dataEntry = { id };
         dataEntry[desc.column] = accessor({ v: { id }, i: null } as IDataRow); // i is not used by the accessor function

--- a/src/util.ts
+++ b/src/util.ts
@@ -130,6 +130,7 @@ export function shuffle(arr: Array<any>): Array<any> {
 
 /**
  * Identify scores through their `lazyLoaded` attribute.
+ * The `lazyLoaded` property is set in `addLazyColumn()` in in tdp_core\src\lineup\internal\column.ts
  * @param column Column description
  */
 export function isScoreColumn(colDesc: IColumnDesc) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -134,7 +134,8 @@ export function shuffle(arr: Array<any>): Array<any> {
  */
 export function isProxyAccessor(accessor: any):  accessor is IAccessorFunc<string|number> {
   if (accessor && typeof(accessor) === 'function' && accessor.length === 1) {
-    return accessor.toString() === '(row) => this.access(row.v)';
+    // test for ES5 accessor string first and then for ES6 accessor string
+    return accessor.toString() === 'function (row) { return _this.access(row.v); }' || accessor.toString() === '(row) => this.access(row.v)';
   }
   return false;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import {IMeasureResult} from './interfaces';
 import {IAccessorFunc} from 'tdp_core/src/lineup/internal/utils';
+import {IColumnDesc, Column} from 'lineupjs';
 
 /**
  * Returns:
@@ -128,16 +129,10 @@ export function shuffle(arr: Array<any>): Array<any> {
 }
 
 /**
- * Checks wether the given function of type IAccessorFunc, i.e. of an AScoreAccessorProxy.
- * Beware: coding horrors await beyond this function header.
- * @param accessor
+ * Identify scores through their `lazyLoaded` attribute.
+ * @param column Column description
  */
-export function isProxyAccessor(accessor: any):  accessor is IAccessorFunc<string|number> {
-  if (accessor && typeof(accessor) === 'function' && accessor.length === 1) {
-    // test for ES5 accessor string first and then for ES6 accessor string
-    // the accessor function is defined in `AScoreAccessorProxy` in tdp_core
-    return accessor.toString() === 'function (row) { return _this.access(row.v); }' || accessor.toString() === '(row) => this.access(row.v)';
-  }
-  return false;
+export function isScoreColumn(colDesc: IColumnDesc) {
+  return colDesc.hasOwnProperty('lazyLoaded');
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -135,6 +135,7 @@ export function shuffle(arr: Array<any>): Array<any> {
 export function isProxyAccessor(accessor: any):  accessor is IAccessorFunc<string|number> {
   if (accessor && typeof(accessor) === 'function' && accessor.length === 1) {
     // test for ES5 accessor string first and then for ES6 accessor string
+    // the accessor function is defined in `AScoreAccessorProxy` in tdp_core
     return accessor.toString() === 'function (row) { return _this.access(row.v); }' || accessor.toString() === '(row) => this.access(row.v)';
   }
   return false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,5 @@
 import {IMeasureResult} from './interfaces';
-import {IAccessorFunc} from 'tdp_core/src/lineup/internal/utils';
-import {IColumnDesc, Column} from 'lineupjs';
+import {IColumnDesc} from 'lineupjs';
 
 /**
  * Returns:


### PR DESCRIPTION
Closes #40 and https://github.com/Caleydo/tdp_bi_bioinfodb/issues/1073

Previously the accessor string was only tested for ES6 build. However, in the release build we transpile the code to ES5, which produces a different accessor string. Hence, the function returned always `false` even though it would have been a correct accessor function. This patch checks for the ES5 accessor string, too. In my tests the calculation also works for the ES5 builds.

![ordino-tourdino-es5](https://user-images.githubusercontent.com/5851088/76607822-edb47780-6514-11ea-9d02-32b0b2b38e59.gif)
