### PR TITLE
Update @types/jquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "tdp_core": "github:datavisyn/tdp_core#develop",
     "@types/d3": "~3.5.36",
-    "@types/jquery": "3.3.33",
+    "@types/jquery": "~3.3.33",
     "@types/node": "^13.7.7",
     "d3": "~3.5.17",
     "d3.parsets": "git+https://github.com/jasondavies/d3-parsets.git#v1.2.4",

--- a/src/tasks/Tasks.ts
+++ b/src/tasks/Tasks.ts
@@ -120,7 +120,7 @@ export abstract class ATouringTask implements ITouringTask {
             const newState = !options.filter(':not(:checked)').empty(); // if not all options are selected --> true = select all, deselect if all options are already selected
             options.each(function () { (this as HTMLOptionElement).selected = newState; }); // set state of all child options
             // update styles in open dropdown
-            $(this).next().find('li').attr('aria-selected', newState.toString()); // accesability and styling
+            $(this).next().find<HTMLElement>('li').attr('aria-selected', newState.toString()); // accesability and styling
 
             $select2.trigger('change').trigger(newState ? 'select2:select' : 'select2:unselect'); // notify select2 of these updates
           });


### PR DESCRIPTION
Fixing the same problem as described in https://github.com/phovea/phovea_clue/issues/189 and fixed in https://github.com/phovea/phovea_clue/pull/190.

If tourdino and phovea_clue are used together in the same workspace the intersected version would be `3.3.33` which throws an error with the additional typings.

Switching to  `~3.3.33` results also in `~3.3.33` for the intersected version in the workspace package.json.