### PR TITLE
Switch to `jstat` package (instead of `jStat`) and update to newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "d3": "~3.5.17",
     "d3.parsets": "git+https://github.com/jasondavies/d3-parsets.git#v1.2.4",
     "d3-grubert-boxplot": "gist:366430a0ac8e6e55ce09b040b5b493a6",
-    "jStat": "1.8.6",
+    "jstat": "^1.9.3",
     "phovea_core": "github:phovea/phovea_core#develop",
     "xxhashjs": "^0.2.2"
   }

--- a/src/Measures.ts
+++ b/src/Measures.ts
@@ -5,7 +5,7 @@ import {ScatterPlot} from './measure_visualization/ScatterPlot';
 import {RelGroupedBarChart} from './measure_visualization/RelGroupedBarChart';
 import {measureResultObj, sleep} from './util';
 import * as d3 from 'd3';
-import {jStat} from 'jStat';
+import {jStat} from 'jstat';
 import {LineChart} from './measure_visualization/LineChart';
 import {JaccardRandomizationWorker, AdjustedRandRandomizationWorker, EnrichmentRandomizationWorker} from './Workers/WorkerManager';
 


### PR DESCRIPTION
Closes Caleydo/tourdino#53


### Summary 
* Tested the panels p-values with the new library update. The results of the calculations where the same.
* Updated imports accordingly.